### PR TITLE
remove z-index from predefined styles

### DIFF
--- a/src/LivewireResourceTimeGrid.php
+++ b/src/LivewireResourceTimeGrid.php
@@ -276,14 +276,11 @@ class LivewireResourceTimeGrid extends Component
             : $eventIndex * $width + $eventIndex
         ;
 
-        $zIndex = ($eventIndex + 1) * 100;
-
         return collect([
             "margin-left: {$marginLeft}%",
             "margin-top: {$marginTop}rem",
             "height: {$height}rem",
             "width: {$width}%",
-            "z-index: {$zIndex};",
         ])->implode('; ');
     }
 }


### PR DESCRIPTION
I fad an issue with modals not overlying the events properly, user should be able to configure that via eventWrapper class and set z-index if needed

```
'eventWrapper' => 'absolute top-0 left-0',
```

Great job with the calendar!
Thanks